### PR TITLE
Feature: Support dashes in wikilinks 1.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# vim local undo folder
+.undodir
+
+# auto-generated tags file
+tags
+
+# yarn package manager lockfile
+yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 1.0.2 (2020-06-30)

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = (options) => {
   }
 
   return Plugin(
-    /\[\[([\w\s/]+)(\|([\w\s/]+))?\]\]/,
+    /\[\[([-\w\s/]+)(\|([-\w\s/]+))?\]\]/,
     (match, utils) => {
       let label = ''
       let pageName = ''

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-wikilinks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "WikiMedia-style links for the markdown-it parser",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,8 @@
     "lint-init": "eslint --init",
     "lint": "eslint index.js",
     "test": "npm run lint && mocha -R spec",
-    "test-ci": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rimraf ./coverage"
+    "test-ci": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rimraf ./coverage",
+    "update-version": "./node_modules/.bin/standard-version"
   },
   "repository": {
     "type": "git",
@@ -36,7 +37,8 @@
     "markdown-it-testgen": "^0.1.4",
     "mocha": "^3.1.0",
     "request": "^2.75.0",
-    "rimraf": "^2.5.4"
+    "rimraf": "^2.5.4",
+    "standard-version": "^8.0.0"
   },
   "dependencies": {
     "extend": "^3.0.0",


### PR DESCRIPTION
I tweaked the wikilink regex slightly to support dashes (`-`) in both the URL and label parts. This comes up often in the content I am parsing.

I've also added `standard-version` as a dev-dep and a `update-version` script to append to the `CHANGELOG.md`, update the manifest version, and commit + tag. I can remove it if it's too much, let me know.

Closes https://github.com/jsepia/markdown-it-wikilinks/issues/2