### PR TITLE
Adds support for broader set of valid characters in links.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = (options) => {
   }
 
   return Plugin(
-    /\[\[([\w\s/]+)(\|([\w\s/]+))?\]\]/,
+    /\[\[([^\|\]\n]+)(\|([^\]\n]+))?\]\]/,
     (match, utils) => {
       let label = ''
       let pageName = ''
@@ -79,7 +79,7 @@ module.exports = (options) => {
         htmlAttrs.push(`${attrName}="${attrValue}"`)
       }
       htmlAttrsString = htmlAttrs.join(' ')
-      
+
       return `<a ${htmlAttrsString}>${label}</a>`
     }
   )

--- a/test/fixtures/wikilinks.txt
+++ b/test/fixtures/wikilinks.txt
@@ -40,6 +40,18 @@ Click [[Wiki Link|here]] to learn about wiki links
 .
 
 .
+Also, [[Wiki.Link|Wiki "Links" can use punctuation!]]
+.
+<p>Also, <a href="./Wiki.Link.html">Wiki "Links" can use punctuation!</a></p>
+.
+
+.
+This is a [[Hyphenated-Wiki-Link]]
+.
+<p>This is a <a href="./Hyphenated-Wiki-Link.html">Hyphenated-Wiki-Link</a></p>
+.
+
+.
 This is [[not a valid wiki link]
 .
 <p>This is [[not a valid wiki link]</p>


### PR DESCRIPTION
This is a great plugin, btw.

I couldn't figure out why this link `[[antibody-dependent enhancement]]` wouldn't render, so I dug into the plugin code and saw that the regular expression for matching wiki link text was limited to `\w\s` which doesn't include hyphens or periods or a lot of other things I am using in my repository.

Figured that this contribution might help others, so am submitting the PR to you in case you're open to cutting a new version.
 
Cheers, 🍻