### PR TITLE
docs: fix option name to match implementation code

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ const html = require('markdown-it')()
 
 Please note that the `generatePagePathFromLabel` function does not get applied for [piped links](https://meta.wikimedia.org/wiki/Help:Piped_link) such as `[[/Misc/Cats/Slate|kitty]]` since those already come with a target. 
 
-### `postProcessPagePath`
+### `postProcessPageName`
 
 A transform applied to every page name. You can override it just like `generatePagePathFromLabel` (see above).
 


### PR DESCRIPTION
# What?

I simply changed the option property name found in the `README.md` documentation to match the actual implementation found in [index.js](https://github.com/jsepia/markdown-it-wikilinks/blob/master/index.js).

From `postProcessPagePath` to `postProcessPageName`.

Using `postProcessPagePath` does not work.

# Why?

I was confused when my transform function wouldn't work after following the documentation until I checked the source code. Turns out I had to use it this way:

```js
const sanitize = require('sanitize-filename');
const slugifyLink = (pageName) => {
  pageName = pageName.trim();
  pageName = pageName.split('/').map(sanitize).join('/');
  pageName = pageName.replace(/\s+/g, '-');
  pageName = pageName.toLowerCase();
  return pageName;
};

const wikilinksPlugin = require('markdown-it-wikilinks')({
  postProcessPageName: slugifyLink,
});
```

I would not change the source code directly because it will entail a new SemVer release and break older versions that relied on using the `postProcessPageName` transform function options property.